### PR TITLE
Add max-width: 100% to CSS to match MDN tutorial

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -38,4 +38,5 @@ h1 {
 img {
   display: block;
   margin: 0 auto;
+  max-width: 100%;
 }


### PR DESCRIPTION
Added `max-width: 100%;` to the CSS file to align with the MDN tutorial. This ensures images scale properly within their containers.