### PR TITLE
Add a default for automatic PR review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,8 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 # ----------------------------------------------------------------------------
 
+* @mdn/content-team
+
 /.github/workflows/ @mdn/engineering
 /.github/CODEOWNERS @mdn/engineering
 /SECURITY.md @mdn/engineering


### PR DESCRIPTION
### Description

PRs in this repo are currently not getting automatically assigned for reviews.


### Solution

- Added `@mdn/content-team` to Settings > Collaborators and teams
- Adding `@mdn/content-team` to CODEOWNERS